### PR TITLE
feature/recommend-menu | OpenAi ChatGpt MCP를 이용한 추천 기능 구현

### DIFF
--- a/src/main/kotlin/order/api/RecommendController.kt
+++ b/src/main/kotlin/order/api/RecommendController.kt
@@ -1,0 +1,19 @@
+package order.api
+
+import order.api.dto.RecommendRequest
+import order.api.dto.RecommendResponse
+import order.application.recommend.RecommendService
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/ai")
+class RecommendController(
+    private val recommendService: RecommendService,
+) {
+    // 아이스크림 메뉴 추천
+    @PostMapping("/recommend")
+    fun recommend(@RequestBody req: RecommendRequest): RecommendResponse = recommendService.recommend(req)
+}

--- a/src/main/kotlin/order/api/dto/McpMessage.kt
+++ b/src/main/kotlin/order/api/dto/McpMessage.kt
@@ -1,0 +1,7 @@
+package order.api.dto
+
+data class McpMessage(
+    val role: String,
+    val content: String,
+    val metadata: Map<String, Any?>? = null
+)

--- a/src/main/kotlin/order/api/dto/RecommendRequest.kt
+++ b/src/main/kotlin/order/api/dto/RecommendRequest.kt
@@ -1,0 +1,6 @@
+package order.api.dto
+
+data class RecommendRequest(
+    val userMessage: String,
+    val history: List<McpMessage>? = null
+)

--- a/src/main/kotlin/order/api/dto/RecommendResponse.kt
+++ b/src/main/kotlin/order/api/dto/RecommendResponse.kt
@@ -1,0 +1,7 @@
+package order.api.dto
+
+data class RecommendResponse(
+    val recommendation: String,
+    val promptTokens: Int? = null,
+    val completionTokens: Int? = null
+)

--- a/src/main/kotlin/order/application/recommend/RecommendService.kt
+++ b/src/main/kotlin/order/application/recommend/RecommendService.kt
@@ -1,0 +1,15 @@
+package order.application.recommend
+
+import order.api.dto.RecommendRequest
+import order.api.dto.RecommendResponse
+import order.domain.recommend.RecommendRepository
+import org.springframework.stereotype.Service
+
+@Service
+class RecommendService(
+    private val recommendRepository: RecommendRepository,
+) {
+    fun recommend(req: RecommendRequest): RecommendResponse {
+        return recommendRepository.recommend(req)
+    }
+}

--- a/src/main/kotlin/order/common/config/AsyncConfig.kt
+++ b/src/main/kotlin/order/common/config/AsyncConfig.kt
@@ -1,0 +1,21 @@
+package order.common.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+
+@EnableAsync
+@Configuration
+class AsyncConfig {
+    @Bean(name = ["menuTaskExecutor"])
+    fun menuTaskExecutor(): ThreadPoolTaskExecutor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = 5 // 최소 스레드 수
+        executor.maxPoolSize = 10 // 최대 스레드 수
+        executor.queueCapacity = 25 // 대기열 크기
+        executor.setThreadNamePrefix("MenuExecutor-")
+        executor.initialize()
+        return executor
+    }
+}

--- a/src/main/kotlin/order/common/config/OpenAiFeignConfig.kt
+++ b/src/main/kotlin/order/common/config/OpenAiFeignConfig.kt
@@ -1,0 +1,20 @@
+package order.common.config
+
+import feign.RequestInterceptor
+import feign.RequestTemplate
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenAiFeignConfig {
+
+    @Value("\${openai.api-key}")
+    private lateinit var apiKey: String
+
+    @Bean
+    fun authInterceptor(): RequestInterceptor = RequestInterceptor { tmpl: RequestTemplate ->
+        tmpl.header("Authorization", "Bearer $apiKey")   // Bearer 인증
+        tmpl.header("Content-Type", "application/json")
+    }
+}

--- a/src/main/kotlin/order/domain/recommend/RecommendRepository.kt
+++ b/src/main/kotlin/order/domain/recommend/RecommendRepository.kt
@@ -1,0 +1,8 @@
+package order.domain.recommend
+
+import order.api.dto.RecommendRequest
+import order.api.dto.RecommendResponse
+
+interface RecommendRepository {
+    fun recommend(req: RecommendRequest): RecommendResponse
+}

--- a/src/main/kotlin/order/infrastructure/feign/openai/OpenAiFeignClient.kt
+++ b/src/main/kotlin/order/infrastructure/feign/openai/OpenAiFeignClient.kt
@@ -1,0 +1,18 @@
+package order.infrastructure.feign.openai
+
+import order.common.config.OpenAiFeignConfig
+import order.infrastructure.feign.openai.dto.ChatCompletionRequest
+import order.infrastructure.feign.openai.dto.ChatCompletionResponse
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+
+@FeignClient(
+    name = "openaiClient",
+    url = "\${openai.base-url}",
+    configuration = [OpenAiFeignConfig::class]
+)
+interface OpenAiFeignClient {
+    @PostMapping("/chat/completions")
+    fun chatCompletions(@RequestBody req: ChatCompletionRequest): ChatCompletionResponse
+}

--- a/src/main/kotlin/order/infrastructure/feign/openai/dto/ChatCompletionRequest.kt
+++ b/src/main/kotlin/order/infrastructure/feign/openai/dto/ChatCompletionRequest.kt
@@ -1,0 +1,9 @@
+package order.infrastructure.feign.openai.dto
+
+import order.infrastructure.recommend.OpenAiMessage
+
+data class ChatCompletionRequest(
+    val model: String,
+    val temperature: Double? = null,
+    val messages: List<OpenAiMessage>
+)

--- a/src/main/kotlin/order/infrastructure/feign/openai/dto/ChatCompletionResponse.kt
+++ b/src/main/kotlin/order/infrastructure/feign/openai/dto/ChatCompletionResponse.kt
@@ -1,0 +1,10 @@
+package order.infrastructure.feign.openai.dto
+
+data class ChatCompletionResponse(
+    val choices: List<Choice> = emptyList(),
+    val usage: Usage? = null
+) {
+    data class Choice(val message: OpenAiMessageContent?)
+    data class OpenAiMessageContent(val role: String?, val content: String?)
+    data class Usage(val prompt_tokens: Int?, val completion_tokens: Int?)
+}

--- a/src/main/kotlin/order/infrastructure/recommend/OpenAiMessage.kt
+++ b/src/main/kotlin/order/infrastructure/recommend/OpenAiMessage.kt
@@ -1,0 +1,6 @@
+package order.infrastructure.recommend
+
+data class OpenAiMessage(
+    val role: String,
+    val content: String
+)

--- a/src/main/kotlin/order/infrastructure/recommend/RecommendRepositoryImpl.kt
+++ b/src/main/kotlin/order/infrastructure/recommend/RecommendRepositoryImpl.kt
@@ -1,0 +1,58 @@
+package order.infrastructure.recommend
+
+import order.api.dto.RecommendRequest
+import order.api.dto.RecommendResponse
+import order.domain.recommend.RecommendRepository
+import order.infrastructure.feign.openai.OpenAiFeignClient
+import order.infrastructure.feign.openai.dto.ChatCompletionRequest
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Repository
+
+@Repository
+class RecommendRepositoryImpl(
+    private val openAi: OpenAiFeignClient,
+    @Value("\${openai.model}") private val model: String,
+    @Value("\${openai.temperature}") private val temperature: Double
+) : RecommendRepository {
+    override fun recommend(req: RecommendRequest): RecommendResponse {
+        // 1) system role로 AI의 역할/톤 고정
+        val systemMsg = OpenAiMessage(
+            role = "system",
+            content = """
+                You are a friendly, concise icecream maker assistant.
+                Recommend 1-2 icecream items from the given menu.
+                Include a short reason and, if relevant, a customization tip (flavor, fruity, calory).
+                Reply in Korean.
+            """.trimIndent()
+        )
+
+        // 2) user role: 메뉴 + 사용자의 상황/취향 메시지
+        val menuList = listOf("바닐라", "초코", "딸기", "망고")
+        val userMsg = OpenAiMessage(
+            role = "user",
+            content = "Menu: [$menuList]\nUser says: ${req.userMessage}"
+        )
+
+        // 3) history가 있으면 그대로 이어붙이기(MCP 멀티턴)
+        val historyMsgs: List<OpenAiMessage> = (req.history ?: emptyList()).map {
+            OpenAiMessage(role = it.role, content = it.content)
+        }
+
+        val messages = listOf(systemMsg) + historyMsgs + userMsg
+
+        val payload = ChatCompletionRequest(
+            model = model,
+            temperature = temperature,
+            messages = messages
+        )
+
+        val res = openAi.chatCompletions(payload)
+        val content = res.choices.firstOrNull()?.message?.content?.trim().orEmpty()
+
+        return RecommendResponse(
+            recommendation = content,
+            promptTokens = res.usage?.prompt_tokens,
+            completionTokens = res.usage?.completion_tokens
+        )
+    }
+}


### PR DESCRIPTION
# feature/recommend-menu | OpenAi ChatGpt MCP를 이용한 추천 기능 구현

AI 기반 아이스크림 추천 기능 구현입니다. 사용자 요청을 처리하고, OpenAI의 채팅 완료 API와 상호작용하며, 개인화된 아이스크림 메뉴 추천을 반환하는 REST API 엔드포인트를 추가합니다. 구현에는 요청/응답 DTO, 서비스 및 저장소 계층, OpenAI 클라이언트 통합, 그리고 지원 구성이 포함됩니다.

**AI 추천 기능**

* 아이스크림 추천 요청을 처리하기 위해 새로운 POST 엔드포인트인 `/api/ai/recommend`를 포함하는 `RecommendController`를 추가했습니다.
* API와 교환되는 데이터를 구조화하기 위해 요청(`RecommendRequest`), 응답(`RecommendResponse`), 메시지 기록(`McpMessage`)에 대한 DTO를 구현했습니다. 

**서비스 및 저장소 Layer**

* 비즈니스 로직을 위한 `RecommendService`와 추상화를 위한 `RecommendRepository` 인터페이스를 생성했습니다. `RecommendRepositoryImpl`은 OpenAI와의 통합 및 추천을 위한 메시지 수집을 담당합니다. 

**OpenAI 통합**

* OpenAI의 채팅 완료 API와 통신하기 위해 `OpenAiFeignClient` 및 관련 DTO(`ChatCompletionRequest`, `ChatCompletionResponse`)를 추가했습니다. 여기에는 시스템/사용자/기록 메시지 지원이 포함됩니다. 

**구성**

* 확장 가능하고 안전한 API 호출을 지원하기 위해 비동기 처리(`AsyncConfig`) 및 OpenAI 인증(`OpenAiFeignConfig`)을 위한 구성 클래스를 도입했습니다. 