### PR TITLE
feature/order-return | 베스트메뉴 domain 객체 반환하도록 적용, 테스트코드 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # order-system
+
 ### 주문 시스템
-이 프로젝트는 아이스크림 주문시스템 구현을 간단하게 설계 및 구현한 공개용 프로젝트입니다. 
+
+이 프로젝트는 아이스크림 주문시스템 구현을 간단하게 설계 및 구현한 공개용 프로젝트입니다.
 코드스타일 및 아키텍처 설계등을 파악하실 수 있습니다.
 
 ---
+
 ## API 목록
+
 아이스크림 주문 시스템 구현
+
 1) 메뉴 조회 API
 2) credit 충전하기 API
 3) 주문하기 API
@@ -13,9 +18,11 @@
 5) Gpt에게 메뉴 추천받기
 
 ## SPEC
+
 Kotlin MySQL JPA Redis
 
 ## DB ERD
+
 ![erd.png](src/main/resources/image/erd.png)
 
 -----
@@ -25,6 +32,7 @@ Kotlin MySQL JPA Redis
 ## 프로젝트 개요
 
 ### 서비스 설명
+
 - **아이스크림 주문 시스템**은 사용자들이 아이스크림 메뉴를 확인하고, 크레딧을 충전하여 주문할 수 있도록 설계된 간단한 API 서비스입니다.
 - 크레딧을 사용해 결제하며, 최근 인기 메뉴를 확인할 수도 있습니다.
 - Gpt를 통해 대화형으로 메뉴 추천 기능도 제공합니다.
@@ -33,7 +41,7 @@ Kotlin MySQL JPA Redis
 
 ## 아키텍처
 
-###  설계 개요
+### 설계 개요
 
 - **Spring Boot** 기반으로 개발
 - **Redis**: 인기 메뉴 캐싱 및 동시성 제어
@@ -45,6 +53,7 @@ Kotlin MySQL JPA Redis
 - **Prometheus, Grafana**: 모니터링
 
 ### 계층 구조
+
 - **Controller Layer**: RESTful API 엔드포인트 제공
 - **Service Layer**: 비즈니스 로직
 - **Domain Layer**: 도메인 로직 집중
@@ -54,14 +63,14 @@ Kotlin MySQL JPA Redis
 
 ## 주요 기능
 
-### 📘 API 목록
+### API 목록
 
-| API      | Method | Endpoint               | 설명       |
-|----------|--------|------------------------|----------|
-| 메뉴 조회    | GET    | `/api/order/menu`      | 전체 메뉴 조회 |
+| API      | Method | Endpoint               | 설명          |
+|----------|--------|------------------------|-------------|
+| 메뉴 조회    | GET    | `/api/order/menu`      | 전체 메뉴 조회    |
 | 인기 메뉴 조회 | GET    | `/api/order/menu/best` | 최근 인기 메뉴 조회 |
 | 크레딧 충전   | POST   | `/api/order/charge`    | 사용자의 크레딧 충전 |
-| 주문 및 결제  | POST   | `/api/order`           | 메뉴 주문 및 결제 |
+| 주문 및 결제  | POST   | `/api/order`           | 메뉴 주문 및 결제  |
 
 ---
 
@@ -95,13 +104,13 @@ Kotlin MySQL JPA Redis
 
 ### 테스트 종류
 
-| 테스트 유형     | 도구       | 설명                     |
-|-----------------|------------|--------------------------|
-| 유닛 테스트     | JUnit, MockK | 개별 메서드 테스트       |
-| 통합 테스트     | Spring Boot Test | 서비스 계층 전체 테스트 |
-
+| 테스트 유형 | 도구               | 설명            |
+|--------|------------------|---------------|
+| 유닛 테스트 | JUnit, MockK     | 개별 메서드 테스트    |
+| 통합 테스트 | Spring Boot Test | 서비스 계층 전체 테스트 |
 
 ### 테스트 실행
+
    ```bash
    ./gradlew test
    ```
@@ -124,6 +133,7 @@ Kotlin MySQL JPA Redis
 ---
 
 ## 향후 개선 사항
+
 - 사용자 인증(JWT) 및 권한 관리
 - 크레딧 충전 내역 테이블 추가
 - 주문/결제 기능을 분리

--- a/src/main/kotlin/order/api/OrderController.kt
+++ b/src/main/kotlin/order/api/OrderController.kt
@@ -55,9 +55,9 @@ class OrderController(
         val bestMenus = bestService.findBestMenu()
         if (bestMenus.isEmpty()) return Response.ok(EMPTY_STATISTICS)
 
-        val menus = menuService.findMenuByIds(bestMenus.map { it.first })
-        val result = menus.zip(bestMenus) { menu, pair ->
-            BestMenuResponse(menuId = menu.id.toInt(), name = menu.name, orderCount = pair.second)
+        val menus = menuService.findMenuByIds(bestMenus.map { it.menuId })
+        val result = menus.zip(bestMenus) { menu, count ->
+            BestMenuResponse(menuId = menu.id.toInt(), name = menu.name, orderCount = count.orderCount)
         }
         return Response.ok(result)
     }

--- a/src/main/kotlin/order/application/best/BestService.kt
+++ b/src/main/kotlin/order/application/best/BestService.kt
@@ -1,5 +1,6 @@
 package order.application.best
 
+import order.domain.best.BestMenu
 import order.domain.best.BestRepository
 import org.springframework.stereotype.Service
 
@@ -7,7 +8,7 @@ import org.springframework.stereotype.Service
 class BestService(
     private val bestRepository: BestRepository,
 ) {
-    fun findBestMenu(): List<Pair<Int, Int>> {
+    fun findBestMenu(): List<BestMenu> {
         return bestRepository.getOrCacheBestMenu()
     }
 }

--- a/src/main/kotlin/order/domain/best/BestMenu.kt
+++ b/src/main/kotlin/order/domain/best/BestMenu.kt
@@ -1,0 +1,6 @@
+package order.domain.best
+
+data class BestMenu(
+    val menuId: Int,
+    val orderCount: Int
+)

--- a/src/main/kotlin/order/domain/best/BestRepository.kt
+++ b/src/main/kotlin/order/domain/best/BestRepository.kt
@@ -4,11 +4,11 @@ import java.time.LocalDate
 import order.api.dto.OrderDetailsRequest
 
 interface BestRepository {
-    fun findBestMenuInRedis(): List<Pair<Int, Int>>
+    fun findBestMenuInRedis(): List<BestMenu>
 
-    fun getOrCacheBestMenu(): List<Pair<Int, Int>>
+    fun getOrCacheBestMenu(): List<BestMenu>
 
-    fun findBestMenuInDB(): List<Pair<Int, Int>>
+    fun findBestMenuInDB(): List<BestMenu>
 
     fun increaseOrderCountInRedis(orders: List<OrderDetailsRequest>): List<Long>
 

--- a/src/test/kotlin/order/api/OrderControllerTest.kt
+++ b/src/test/kotlin/order/api/OrderControllerTest.kt
@@ -32,7 +32,6 @@ class OrderControllerTest {
 
     @Test
     fun `인기메뉴 없을 때 집계 없음 메시지 반환`() {
-        // bestService.findBestMenu()가 빈 리스트 반환하도록 mocking
         given(bestService.findBestMenu()).willReturn(emptyList())
 
         val result = mockMvc.get("/api/order/best-menu")

--- a/src/test/kotlin/order/common/RedissonConfigTest.kt
+++ b/src/test/kotlin/order/common/RedissonConfigTest.kt
@@ -1,0 +1,36 @@
+package order.common
+
+import order.common.config.DistributedLockProperties
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.redisson.api.RedissonClient
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RedissonConfigTest {
+
+    @Autowired
+    lateinit var redissonClient: RedissonClient
+
+    @Autowired
+    lateinit var distributedLockProperties: DistributedLockProperties
+
+    @Test
+    fun `RedissonClient 빈이 정상적으로 생성된다`() {
+        assertNotNull(redissonClient)
+    }
+
+    @Test
+    fun `DistributedLockProperties가 정상적으로 바인딩된다`() {
+        assertNotNull(distributedLockProperties)
+        assertEquals(5L, distributedLockProperties.defaultWaitTime)
+        assertEquals(30L, distributedLockProperties.defaultLeaseTime)
+        assertEquals(30000L, distributedLockProperties.watchdogTimeout)
+        assertEquals("lock", distributedLockProperties.keyPrefix)
+    }
+}

--- a/src/test/kotlin/order/common/config/CacheConfigTest.kt
+++ b/src/test/kotlin/order/common/config/CacheConfigTest.kt
@@ -1,0 +1,21 @@
+package order.common.config;
+
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.cache.CacheManager
+
+@SpringBootTest
+class CacheConfigTest {
+    @Autowired
+    lateinit var cacheManager: CacheManager
+
+    @Test
+    fun `Caffeine CacheManager 빈이 정상적으로 생성된다`() {
+        assertNotNull(cacheManager)
+        assertTrue(cacheManager.cacheNames.contains("menu"))
+        assertTrue(cacheManager.cacheNames.contains("menus"))
+    }
+}

--- a/src/test/kotlin/order/infrastructure/best/BestRepositoryImplIntegrationTest.kt
+++ b/src/test/kotlin/order/infrastructure/best/BestRepositoryImplIntegrationTest.kt
@@ -1,10 +1,10 @@
-package order.domain.best
+package order.infrastructure.best
 
 import TestJpaConfig
 import java.time.LocalDate
 import order.api.dto.OrderDetailsRequest
 import order.common.config.JacksonConfig
-import order.infrastructure.best.BestJpaRepository
+import order.domain.best.BestRepository
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -18,7 +18,7 @@ import org.springframework.transaction.annotation.Transactional
 @SpringBootTest
 @ActiveProfiles("test")
 @Import(JacksonConfig::class, TestJpaConfig::class)
-class BestRepositoryIntegrationTest @Autowired constructor(
+class BestRepositoryImplIntegrationTest @Autowired constructor(
     private val bestRepository: BestRepository,
     private val bestJpaRepository: BestJpaRepository,
     private val redissonClient: RedissonClient,
@@ -42,8 +42,8 @@ class BestRepositoryIntegrationTest @Autowired constructor(
             val bestMenus = bestRepository.findBestMenuInRedis()
 
             // then
-            assertTrue(bestMenus.any { it.first == MENU_ID_10 && it.second == MENU_COUNT_10 })
-            assertTrue(bestMenus.any { it.first == MENU_ID_20 && it.second == MENU_COUNT_20 })
+            assertTrue(bestMenus.any { it.menuId == MENU_ID_10 && it.orderCount == MENU_COUNT_10 })
+            assertTrue(bestMenus.any { it.menuId == MENU_ID_20 && it.orderCount == MENU_COUNT_20 })
         } finally {
             // redis 기록 원복
             val map = redissonClient.getMap<String, Long>("best_menu")


### PR DESCRIPTION
# feature/order-return | 베스트메뉴 domain 객체 반환하도록 적용, 테스트코드 추가

인기 메뉴 데이터가 처리되는 방식을 리팩토링하여, 명확성과 유지 관리성을 높이기 위해 `Pair<Int, Int>` 대신 전용 `BestMenu` 데이터 클래스를 사용합니다. 

**리팩토링: 인기 메뉴 데이터 처리**

* 인기 메뉴 항목을 나타내는 새로운 데이터 클래스 `BestMenu`를 도입하여 최상의 메뉴 로직에서 `Pair<Int, Int>`를 모두 대체했습니다. 이는 메서드 시그니처, 저장소 구현 및 관련 테스트 어설션에 영향을 미칩니다.

* 통합 테스트를 업데이트하고 이름을 변경했습니다. 

**테스트: 구성 테스트 추가**

* Redisson 및 분산 잠금 속성이 올바르게 구성되고 삽입되었는지 확인하기 위해 `RedissonConfigTest`를 추가했습니다.
* 캐시 관리자가 예상 캐시 이름으로 올바르게 설정되었는지 확인하기 위해 `CacheConfigTest`를 추가했습니다.

**문서: README 개선**

**인기메뉴 api call 확인**
```
{
    "code": 200,
    "message": "ok",
    "value": [
        {
            "menuId": 1,
            "name": "바닐라",
            "orderCount": 298
        },
        {
            "menuId": 2,
            "name": "초코",
            "orderCount": 247
        },
        {
            "menuId": 4,
            "name": "망고",
            "orderCount": 185
        }
    ]
}
``` 
