### PR TITLE
redis 동시성 테스트 추가

### DIFF
--- a/src/test/kotlin/order/infrastructure/best/BestRepositoryImplIntegrationTest.kt
+++ b/src/test/kotlin/order/infrastructure/best/BestRepositoryImplIntegrationTest.kt
@@ -2,6 +2,9 @@ package order.infrastructure.best
 
 import TestJpaConfig
 import java.time.LocalDate
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.stream.IntStream
 import order.api.dto.OrderDetailsRequest
 import order.common.config.JacksonConfig
 import order.domain.best.BestRepository
@@ -15,9 +18,9 @@ import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 
-@SpringBootTest
 @ActiveProfiles("test")
 @Import(JacksonConfig::class, TestJpaConfig::class)
+@SpringBootTest(properties = ["spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration"])
 class BestRepositoryImplIntegrationTest @Autowired constructor(
     private val bestRepository: BestRepository,
     private val bestJpaRepository: BestJpaRepository,
@@ -74,5 +77,61 @@ class BestRepositoryImplIntegrationTest @Autowired constructor(
             // 배치 기록 원복
             bestJpaRepository.deleteByMenuId(10)
         }
+    }
+
+    @Test
+    fun `increaseOrderCountInRedis 동시성 테스트, CountDownLatch 사용`() {
+        val menuId = 100
+        val threadCount = 10
+        val orderCountPerThread = 5
+        val latch = CountDownLatch(threadCount)
+        val executor = Executors.newFixedThreadPool(threadCount)
+
+        // redis 초기화
+        val map = redissonClient.getMap<String, String>("best_menu")
+        map.remove(menuId.toString())
+
+        repeat(threadCount) {
+            executor.submit {
+                bestRepository.increaseOrderCountInRedis(
+                    listOf(OrderDetailsRequest(menuId, orderCountPerThread, 1000))
+                )
+                latch.countDown()
+            }
+        }
+        latch.await()
+        executor.shutdown()
+
+        val finalCount = map[menuId.toString()]?.toLong() ?: 0L
+        assertEquals((threadCount * orderCountPerThread).toLong(), finalCount)
+
+        // 원복
+        map.remove(menuId.toString())
+    }
+
+    @Test
+    fun `decreaseOrderCountInRedis 동시성 테스트, IntStream parallel 사용`() {
+        val menuId = 200
+        val initialCount = 20
+        val decreasePerThread = 5
+        val threadCount = 4
+
+        // redis 초기화
+        val map = redissonClient.getMap<String, String>("best_menu")
+        map.put(menuId.toString(), initialCount.toString())
+
+        IntStream.range(0, threadCount)
+            .parallel()
+            .forEach {
+                bestRepository.decreaseOrderCountInRedis(
+                    listOf(OrderDetailsRequest(menuId, decreasePerThread, 1000))
+                )
+            }
+
+        val finalCount = map[menuId.toString()]?.toLong() ?: 0L
+        assertTrue(finalCount <= 0L)
+
+        // 원복
+        map.remove(menuId.toString())
     }
 }


### PR DESCRIPTION
# redis 동시성 테스트 추가

1. CountDownLatch 이용
2. IntStream parallel 이용

Redis 기반 주문 수 계산 작업의 스레드 안전성을 검증하는 동시 테스트 케이스를 추가하여 `BestRepositoryImpl` 통합 테스트를 향상시킵니다. 또한, 더 빠르고 집중적인 테스트를 위해 Kafka 자동 구성을 제외하도록 Spring Boot 테스트 구성을 업데이트했습니다.


<img width="467" height="247" alt="스크린샷 2025-09-14 오후 11 08 57" src="https://github.com/user-attachments/assets/b9b38bc1-b8ff-4a36-9619-d9159973e3b6" />
