### PR TITLE
feature/redis-fallback | resilience4j로 Redis fallback 구현하기

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,10 @@ dependencies {
     implementation("io.gatling:gatling-core:3.10.5")
     implementation("io.gatling:gatling-http:3.10.5")
 
+    // resilience4j
+    implementation("io.github.resilience4j:resilience4j-spring-boot3:2.2.0")
+    implementation("io.github.resilience4j:resilience4j-ratelimiter:2.2.0")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation(kotlin("test"))
     testImplementation("io.kotest:kotest-runner-junit5:5.6.1")

--- a/src/main/kotlin/order/common/config/Resilience4jConfig.kt
+++ b/src/main/kotlin/order/common/config/Resilience4jConfig.kt
@@ -1,0 +1,25 @@
+package order.common.config
+
+import io.github.resilience4j.ratelimiter.RateLimiter
+import io.github.resilience4j.ratelimiter.RateLimiterConfig
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Duration
+
+@Configuration
+class Resilience4jConfig {
+    @Bean
+    fun rateLimiterRegistry(): RateLimiterRegistry {
+        val config = RateLimiterConfig.custom()
+            .limitForPeriod(10)
+            .limitRefreshPeriod(Duration.ofSeconds(1))
+            .timeoutDuration(Duration.ZERO)
+            .build()
+        return RateLimiterRegistry.of(mapOf("dbFallbackLimiter" to config))
+    }
+
+    @Bean
+    fun dbFallbackLimiter(rateLimiterRegistry: RateLimiterRegistry): RateLimiter =
+        rateLimiterRegistry.rateLimiter("dbFallbackLimiter")
+}

--- a/src/main/kotlin/order/infrastructure/best/BestRepositoryImpl.kt
+++ b/src/main/kotlin/order/infrastructure/best/BestRepositoryImpl.kt
@@ -1,14 +1,16 @@
 package order.infrastructure.best
 
 import com.querydsl.jpa.impl.JPAQueryFactory
-import java.time.Duration
-import java.time.LocalDate
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter
 import order.api.dto.OrderDetailsRequest
 import order.domain.best.BestMenu
 import order.domain.best.BestRepository
 import order.domain.best.MenuOrderStatics
 import org.redisson.api.RedissonClient
 import org.springframework.stereotype.Repository
+import java.time.Duration
+import java.time.LocalDate
 
 @Repository
 class BestRepositoryImpl(
@@ -16,6 +18,8 @@ class BestRepositoryImpl(
     private val bestJpaRepository: BestJpaRepository,
     private val queryFactory: JPAQueryFactory,
 ) : BestRepository {
+    private val logger = KotlinLogging.logger {}
+
     override fun findBestMenuInRedis(): List<BestMenu> {
         val map = redissonClient.getMap<String, String>(BEST_MENU_KEY)
 
@@ -26,6 +30,7 @@ class BestRepositoryImpl(
             .map { BestMenu(it.key.toInt(), it.value.toInt()) }
     }
 
+    @RateLimiter(name = "dbFallbackLimiter", fallbackMethod = "fallbackToEmptyBestMenu")
     override fun getOrCacheBestMenu(): List<BestMenu> {
         val cached = findBestMenuInRedis()
         if (cached.isNotEmpty()) return cached
@@ -35,6 +40,11 @@ class BestRepositoryImpl(
             cacheBestMenuToRedis(dbResult) // 집계 결과를 Redis에 저장
         }
         return dbResult
+    }
+
+    fun fallbackToEmptyBestMenu(e: Throwable): List<BestMenu> {
+        logger.error(e) { "Redis fallback : BestMenu 조회 실패" }
+        return findBestMenuInDB()
     }
 
     private fun cacheBestMenuToRedis(menuIdCounts: List<BestMenu>) {
@@ -83,6 +93,11 @@ class BestRepositoryImpl(
             }
             updatedCount
         }
+    }
+
+    fun fallbackToDB(orders: List<OrderDetailsRequest>, e: Throwable): List<Long> {
+        recordMenuStatisticsBatch(orders)
+        return orders.map { it.count.toLong() }
     }
 
     override fun findMenuByDate(today: LocalDate, menuIds: List<Int>): List<MenuOrderStatics> =

--- a/src/test/kotlin/order/common/config/Resilience4jConfigTest.kt
+++ b/src/test/kotlin/order/common/config/Resilience4jConfigTest.kt
@@ -1,0 +1,24 @@
+package order.common.config
+
+import io.github.resilience4j.ratelimiter.RateLimiter
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@SpringBootTest(classes = [Resilience4jConfig::class])
+class Resilience4jConfigTest {
+
+    @Autowired
+    lateinit var dbFallbackLimiter: RateLimiter
+
+    @Test
+    fun `dbFallbackLimiter 빈이 정상적으로 생성된다`() {
+        assertNotNull(dbFallbackLimiter)
+        assertEquals("dbFallbackLimiter", dbFallbackLimiter.name)
+    }
+}


### PR DESCRIPTION
# feature/redis-fallback | resilience4j로 Redis fallback 구현하기

Resilience4j를 사용하여 최상의 메뉴 캐싱 로직에 속도 제한을 도입하고, 안정성 향상을 위한 대체 메커니즘을 추가하며, 이러한 변경 사항을 지원하기 위한 구성 및 테스트를 포함합니다. 주요 목표는 캐싱 또는 데이터베이스 액세스 실패가 원활하게 처리되도록 하여 시스템 과부하를 방지하고 내결함성을 향상시키는 것입니다.

**Resilience4j 속도 제한 통합**

* 요청 제한 및 새로 고침 기간에 대한 사용자 지정 설정을 포함하는 `RateLimiterRegistry` 및 `dbFallbackLimiter` 빈을 정의하기 위해 `Resilience4jConfig` 구성 클래스를 추가했습니다.
* `BestRepositoryImpl`의 `getOrCacheBestMenu` 메서드에 `@RateLimiter` 어노테이션을 추가하여 `dbFallbackLimiter` 사용 및 속도 제한 위반 처리를 위한 대체 메서드를 지정했습니다.

**폴백 및 오류 처리 개선**

* `BestRepositoryImpl`에 `fallbackToEmptyBestMenu` 및 `fallbackToDB` 메서드를 구현하여 속도 제한을 초과하거나 오류가 발생할 경우 로깅 및 데이터베이스 쿼리 폴백을 포함한 대체 로직을 제공했습니다. 

**테스트 및 검증**

* `dbFallbackLimiter` 빈이 애플리케이션 컨텍스트에서 올바르게 생성되고 구성되었는지 확인하기 위해 `Resilience4jConfigTest`를 추가했습니다.

**TODO**

* 실제 코드 검증 완료하였으나 testcode 작성에는 AOP 접근 한계가 있어, 실무라고 한다면 @RateLimiter를 걷어내고 rateLimitRegistry를 주입받아 try-catch 로 리팩토링하는 방법을 적용하면 좋다. 
