### PR TITLE
feat: 크레딧 잔액 조회 API + 주문 내역 조회 API (#21, #22)

### DIFF
--- a/src/main/kotlin/order/api/OrderController.kt
+++ b/src/main/kotlin/order/api/OrderController.kt
@@ -4,6 +4,8 @@ import jakarta.validation.Valid
 import order.api.dto.BestMenuResponse
 import order.api.dto.CreditChargeRequest
 import order.api.dto.MenuResponse
+import order.api.dto.OrderDetailResponse
+import order.api.dto.OrderHistoryResponse
 import order.api.dto.OrderRequest
 import order.api.dto.Response
 import order.application.best.BestService
@@ -12,6 +14,7 @@ import order.application.order.OrderService
 import order.application.user.UserCreditService
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -47,6 +50,22 @@ class OrderController(
     fun order(@RequestBody @Valid request: OrderRequest): Response<String> {
         val result = orderService.order(request)
         return Response.ok("주문이 완료되었습니다. 사용자 ID: ${result.userId}, 총 결제 가격: ${result.price}")
+    }
+
+    // 주문 내역 조회
+    @GetMapping("/history/{userId}")
+    fun findOrderHistory(@PathVariable userId: Long): Response<List<OrderHistoryResponse>> {
+        val results = orderService.findOrdersByUserId(userId)
+        return Response.ok(results.map { result ->
+            OrderHistoryResponse(
+                orderId = result.history.id,
+                price = result.history.price,
+                createdAt = result.history.createdAt,
+                details = result.details.map { d ->
+                    OrderDetailResponse(menuId = d.menuId, count = d.count, menuPrice = d.menuPrice)
+                }
+            )
+        })
     }
 
     // 인기메뉴 조회

--- a/src/main/kotlin/order/api/OrderController.kt
+++ b/src/main/kotlin/order/api/OrderController.kt
@@ -2,6 +2,7 @@ package order.api
 
 import jakarta.validation.Valid
 import order.api.dto.BestMenuResponse
+import order.api.dto.CreditBalanceResponse
 import order.api.dto.CreditChargeRequest
 import order.api.dto.MenuResponse
 import order.api.dto.OrderRequest
@@ -12,6 +13,7 @@ import order.application.order.OrderService
 import order.application.user.UserCreditService
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -47,6 +49,13 @@ class OrderController(
     fun order(@RequestBody @Valid request: OrderRequest): Response<String> {
         val result = orderService.order(request)
         return Response.ok("주문이 완료되었습니다. 사용자 ID: ${result.userId}, 총 결제 가격: ${result.price}")
+    }
+
+    // 크레딧 잔액 조회
+    @GetMapping("/credit/{userId}")
+    fun getCredit(@PathVariable userId: Long): Response<CreditBalanceResponse> {
+        val userCredit = creditService.getBalance(userId)
+        return Response.ok(CreditBalanceResponse(userId = userCredit.id, credits = userCredit.credits))
     }
 
     // 인기메뉴 조회

--- a/src/main/kotlin/order/api/OrderController.kt
+++ b/src/main/kotlin/order/api/OrderController.kt
@@ -69,8 +69,8 @@ class OrderController(
                 orderId = result.history.id,
                 price = result.history.price,
                 createdAt = result.history.createdAt,
-                details = result.details.map { d ->
-                    OrderDetailResponse(menuId = d.menuId, count = d.count, menuPrice = d.menuPrice)
+                details = result.details.map { detail ->
+                    OrderDetailResponse(menuId = detail.menuId, count = detail.count, menuPrice = detail.menuPrice)
                 }
             )
         })

--- a/src/main/kotlin/order/api/dto/CreditBalanceResponse.kt
+++ b/src/main/kotlin/order/api/dto/CreditBalanceResponse.kt
@@ -1,0 +1,6 @@
+package order.api.dto
+
+data class CreditBalanceResponse(
+    val userId: Long,
+    val credits: Int,
+)

--- a/src/main/kotlin/order/api/dto/OrderHistoryResponse.kt
+++ b/src/main/kotlin/order/api/dto/OrderHistoryResponse.kt
@@ -1,0 +1,16 @@
+package order.api.dto
+
+import java.time.LocalDateTime
+
+data class OrderHistoryResponse(
+    val orderId: Long,
+    val price: Int,
+    val createdAt: LocalDateTime,
+    val details: List<OrderDetailResponse>,
+)
+
+data class OrderDetailResponse(
+    val menuId: Int,
+    val count: Int,
+    val menuPrice: Int,
+)

--- a/src/main/kotlin/order/application/order/OrderService.kt
+++ b/src/main/kotlin/order/application/order/OrderService.kt
@@ -4,6 +4,7 @@ import order.api.dto.OrderRequest
 import order.common.config.DistributedLock
 import order.domain.best.BestRepository
 import order.domain.order.OrderHistory
+import order.domain.order.OrderHistoryResult
 import order.domain.order.OrderRepository
 import order.domain.order.OrderValidation
 import order.domain.user.UserCreditRepository
@@ -68,6 +69,11 @@ class OrderService(
                 }
             }
         }
+    }
+
+    @Transactional(readOnly = true)
+    fun findOrdersByUserId(userId: Long): List<OrderHistoryResult> {
+        return orderRepository.findByUserId(userId)
     }
 
     @Transactional

--- a/src/main/kotlin/order/application/user/UserCreditService.kt
+++ b/src/main/kotlin/order/application/user/UserCreditService.kt
@@ -1,5 +1,6 @@
 package order.application.user
 
+import order.domain.user.UserCredit
 import order.domain.user.UserCreditRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -11,5 +12,11 @@ class UserCreditService(
     @Transactional
     fun charge(userId: Long, credits: Int) {
         userCreditRepository.chargeCredits(userId, credits)
+    }
+
+    @Transactional(readOnly = true)
+    fun getBalance(userId: Long): UserCredit {
+        return userCreditRepository.findById(userId)
+            ?: throw NoSuchElementException("존재하지 않는 사용자입니다.")
     }
 }

--- a/src/main/kotlin/order/common/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/order/common/GlobalExceptionHandler.kt
@@ -21,4 +21,10 @@ class GlobalExceptionHandler {
         logger.warn(ex) { ex.message ?: ErrorCode.INVALID_INPUT_VALUE.message }
         return Response.error(ErrorCode.INVALID_INPUT_VALUE, ex.message)
     }
+
+    @ExceptionHandler(NoSuchElementException::class)
+    fun handleNoSuchElementException(ex: NoSuchElementException): Response<Nothing> {
+        logger.warn(ex) { ex.message ?: ErrorCode.NOT_FOUND.message }
+        return Response.error(ErrorCode.NOT_FOUND, ex.message)
+    }
 }

--- a/src/main/kotlin/order/domain/order/OrderHistoryResult.kt
+++ b/src/main/kotlin/order/domain/order/OrderHistoryResult.kt
@@ -1,0 +1,6 @@
+package order.domain.order
+
+data class OrderHistoryResult(
+    val history: OrderHistory,
+    val details: List<OrderDetails>,
+)

--- a/src/main/kotlin/order/domain/order/OrderRepository.kt
+++ b/src/main/kotlin/order/domain/order/OrderRepository.kt
@@ -5,4 +5,5 @@ import order.api.dto.OrderRequest
 interface OrderRepository {
     fun saveOrder(request: OrderRequest): OrderHistory
     fun publishOrderEvent(id: Long, request: OrderRequest)
+    fun findByUserId(userId: Long): List<OrderHistoryResult>
 }

--- a/src/main/kotlin/order/infrastructure/order/OrderJpaRepository.kt
+++ b/src/main/kotlin/order/infrastructure/order/OrderJpaRepository.kt
@@ -1,5 +1,16 @@
 package order.infrastructure.order
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
-interface OrderJpaRepository : JpaRepository<OrderHistoryEntity, Long>
+interface OrderJpaRepository : JpaRepository<OrderHistoryEntity, Long> {
+
+    @Query("""
+        SELECT DISTINCT oh FROM OrderHistoryEntity oh
+        LEFT JOIN FETCH oh.orderDetails
+        WHERE oh.userId = :userId AND oh.deleted = false
+        ORDER BY oh.id DESC
+    """)
+    fun findAllByUserIdWithDetails(@Param("userId") userId: Long): List<OrderHistoryEntity>
+}

--- a/src/main/kotlin/order/infrastructure/order/OrderRepositoryImpl.kt
+++ b/src/main/kotlin/order/infrastructure/order/OrderRepositoryImpl.kt
@@ -4,6 +4,7 @@ import order.api.dto.OrderRequest
 import order.domain.event.OrderDetailsEvent
 import order.domain.event.OrderHistoryEvent
 import order.domain.order.OrderHistory
+import order.domain.order.OrderHistoryResult
 import order.domain.order.OrderRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.kafka.core.KafkaTemplate
@@ -49,6 +50,15 @@ class OrderRepositoryImpl(
                     logger.error(ex) { "Kafka 전송 실패" }
                 }
             }
+    }
+
+    override fun findByUserId(userId: Long): List<OrderHistoryResult> {
+        return orderJpaRepository.findAllByUserIdWithDetails(userId).map { entity ->
+            OrderHistoryResult(
+                history = entity.toOrderHistory(),
+                details = entity.orderDetails.map { it.toOrderDetails() }
+            )
+        }
     }
 
     companion object {

--- a/src/test/kotlin/order/api/OrderControllerIntegrationTest.kt
+++ b/src/test/kotlin/order/api/OrderControllerIntegrationTest.kt
@@ -119,4 +119,41 @@ class OrderControllerIntegrationTest @Autowired constructor(
         assert(json["value"].asText().contains("사용자 ID"))
         assert(json["value"].asText().contains("총 결제 가격"))
     }
+
+    @Test
+    fun `주문 내역 조회시 주문 목록 반환`() {
+        val orderDetails = listOf(OrderDetailsRequest(menuId = testMenuId, count = 1, menuPrice = 6000))
+        val orderRequest = OrderRequest(userId = testUserId, orderDetails = orderDetails, price = 6000)
+        mockMvc.post("/api/order") {
+            contentType = MediaType.APPLICATION_JSON
+            content = objectMapper.writeValueAsString(orderRequest)
+        }.andExpect { status { isOk() } }
+
+        val result = mockMvc.get("/api/order/history/$testUserId")
+            .andExpect { status { isOk() } }
+            .andReturn()
+
+        val json: JsonNode = objectMapper.readTree(
+            result.response.getContentAsString(StandardCharsets.UTF_8)
+        )
+        assert(json["code"].asInt() == 200)
+        assert(json["value"].isArray)
+        assert(json["value"].size() > 0)
+        assert(json["value"][0]["orderId"] != null)
+        assert(json["value"][0]["details"].isArray)
+    }
+
+    @Test
+    fun `주문 내역이 없는 경우 빈 배열 반환`() {
+        val result = mockMvc.get("/api/order/history/88888")
+            .andExpect { status { isOk() } }
+            .andReturn()
+
+        val json: JsonNode = objectMapper.readTree(
+            result.response.getContentAsString(StandardCharsets.UTF_8)
+        )
+        assert(json["code"].asInt() == 200)
+        assert(json["value"].isArray)
+        assert(json["value"].size() == 0)
+    }
 }

--- a/src/test/kotlin/order/api/OrderControllerIntegrationTest.kt
+++ b/src/test/kotlin/order/api/OrderControllerIntegrationTest.kt
@@ -101,6 +101,36 @@ class OrderControllerIntegrationTest @Autowired constructor(
     }
 
     @Test
+    fun `크레딧 잔액 조회시 userId와 잔액 반환`() {
+        val result = mockMvc.get("/api/order/credit/$testUserId")
+            .andExpect { status { isOk() } }
+            .andReturn()
+
+        val response = result.response.getContentAsString(StandardCharsets.UTF_8)
+        val json: JsonNode = objectMapper.readTree(response)
+
+        assert(json["code"].asInt() == 200)
+        assert(json["message"].asText() == "ok")
+        assert(json["value"]["userId"].asLong() == testUserId)
+        assert(json["value"]["credits"].asInt() >= 0)
+    }
+
+    @Test
+    fun `존재하지 않는 사용자 크레딧 조회시 404 코드 반환`() {
+        val nonExistentUserId = 0L
+
+        val result = mockMvc.get("/api/order/credit/$nonExistentUserId")
+            .andExpect { status { isOk() } }
+            .andReturn()
+
+        val response = result.response.getContentAsString(StandardCharsets.UTF_8)
+        val json: JsonNode = objectMapper.readTree(response)
+
+        assert(json["code"].asInt() == 404)
+        assert(json["message"].asText() == "존재하지 않는 사용자입니다.")
+    }
+
+    @Test
     fun `주문 성공시 주문 완료 메시지 반환`() {
         val orderDetails = listOf(OrderDetailsRequest(menuId = testMenuId, count = 1, menuPrice = 6000))
         val request = OrderRequest(userId = testUserId, orderDetails = orderDetails, price = 6000)

--- a/src/test/kotlin/order/api/OrderControllerIntegrationTest.kt
+++ b/src/test/kotlin/order/api/OrderControllerIntegrationTest.kt
@@ -10,6 +10,8 @@ import order.api.dto.OrderRequest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
@@ -29,6 +31,7 @@ class OrderControllerIntegrationTest @Autowired constructor(
     val mockMvc: MockMvc,
     val objectMapper: ObjectMapper,
     val jdbcTemplate: JdbcTemplate,
+    val namedParameterJdbcTemplate: NamedParameterJdbcTemplate,
 ) {
     private val testUserId = 99999L
     private val testMenuId = 99999
@@ -57,9 +60,9 @@ class OrderControllerIntegrationTest @Autowired constructor(
         )
         if (orderIds.isNotEmpty()) {
             // 해당 주문 id와 menu_id로 상세 내역 삭제
-            jdbcTemplate.update(
-                "DELETE FROM ORDER_DETAILS WHERE order_id IN (${orderIds.joinToString(",")}) AND menu_id = ?",
-                testMenuId
+            namedParameterJdbcTemplate.update(
+                "DELETE FROM ORDER_DETAILS WHERE order_id IN (:orderIds) AND menu_id = :menuId",
+                MapSqlParameterSource().addValue("orderIds", orderIds).addValue("menuId", testMenuId)
             )
         }
         jdbcTemplate.update("DELETE FROM ORDER_HISTORY WHERE user_id = ?", testUserId)

--- a/src/test/kotlin/order/api/OrderControllerUnitTest.kt
+++ b/src/test/kotlin/order/api/OrderControllerUnitTest.kt
@@ -1,5 +1,6 @@
 package order.api
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
@@ -17,6 +18,7 @@ import order.application.user.UserCreditService
 import order.domain.best.BestMenu
 import order.domain.menu.Menu
 import order.domain.order.OrderHistory
+import order.domain.user.UserCredit
 import java.time.LocalDateTime
 
 class OrderControllerUnitTest : DescribeSpec({
@@ -145,6 +147,33 @@ class OrderControllerUnitTest : DescribeSpec({
 
                 response.code shouldBe 200
                 response.value shouldBe "집계 된 메뉴가 없습니다."
+            }
+        }
+    }
+
+    describe("getCredit") {
+        context("존재하는 사용자 ID가 주어졌을 때") {
+            it("CreditBalanceResponse를 Response로 감싸서 반환한다") {
+                val userCredit = UserCredit(id = 1L, credits = 5000)
+                every { creditService.getBalance(1L) } returns userCredit
+
+                val response = orderController.getCredit(1L)
+
+                response.code shouldBe 200
+                response.value!!.userId shouldBe 1L
+                response.value!!.credits shouldBe 5000
+                verify(exactly = 1) { creditService.getBalance(1L) }
+            }
+        }
+
+        context("존재하지 않는 사용자 ID가 주어졌을 때") {
+            it("NoSuchElementException을 그대로 전파한다") {
+                every { creditService.getBalance(999L) } throws NoSuchElementException("존재하지 않는 사용자입니다.")
+
+                val exception = shouldThrow<NoSuchElementException> {
+                    orderController.getCredit(999L)
+                }
+                exception.message shouldBe "존재하지 않는 사용자입니다."
             }
         }
     }

--- a/src/test/kotlin/order/api/OrderControllerUnitTest.kt
+++ b/src/test/kotlin/order/api/OrderControllerUnitTest.kt
@@ -17,6 +17,7 @@ import order.application.user.UserCreditService
 import order.domain.best.BestMenu
 import order.domain.menu.Menu
 import order.domain.order.OrderHistory
+import order.domain.order.OrderHistoryResult
 import java.time.LocalDateTime
 
 class OrderControllerUnitTest : DescribeSpec({
@@ -105,6 +106,35 @@ class OrderControllerUnitTest : DescribeSpec({
                 response.code shouldBe 200
                 response.value!!.contains("1") shouldBe true
                 response.value!!.contains("6000") shouldBe true
+            }
+        }
+    }
+
+    describe("findOrderHistory") {
+        context("주문 내역이 있는 사용자 ID가 주어졌을 때") {
+            it("OrderHistoryResponse 목록을 반환한다") {
+                val now = LocalDateTime.now()
+                val orderHistory = OrderHistory(id = 1L, userId = 1L, price = 6000, createdBy = "test", createdAt = now, modifiedBy = "test", modifiedAt = now)
+                val results = listOf(OrderHistoryResult(history = orderHistory, details = emptyList()))
+                every { orderService.findOrdersByUserId(1L) } returns results
+
+                val response = orderController.findOrderHistory(1L)
+
+                response.code shouldBe 200
+                response.value!!.size shouldBe 1
+                response.value!![0].orderId shouldBe 1L
+                response.value!![0].price shouldBe 6000
+            }
+        }
+
+        context("주문 내역이 없을 때") {
+            it("빈 목록을 반환한다") {
+                every { orderService.findOrdersByUserId(any()) } returns emptyList()
+
+                val response = orderController.findOrderHistory(999L)
+
+                response.code shouldBe 200
+                response.value!!.isEmpty() shouldBe true
             }
         }
     }

--- a/src/test/kotlin/order/application/user/UserCreditServiceTest.kt
+++ b/src/test/kotlin/order/application/user/UserCreditServiceTest.kt
@@ -53,4 +53,32 @@ class UserCreditServiceTest {
         }
         assertEquals("존재하지 않는 사용자입니다.", exception.message)
     }
+
+    @Test
+    fun `정상적으로 크레딧 잔액 조회`() {
+        // given
+        val userId = 1L
+        val userCredit = UserCredit(id = userId, credits = 5000)
+        every { userCreditRepository.findById(userId) } returns userCredit
+
+        // when
+        val result = userCreditService.getBalance(userId)
+
+        // then
+        assertEquals(userId, result.id)
+        assertEquals(5000, result.credits)
+    }
+
+    @Test
+    fun `존재하지 않는 사용자 잔액 조회 예외`() {
+        // given
+        val userId = 999L
+        every { userCreditRepository.findById(userId) } returns null
+
+        // when & then
+        val exception = assertThrows<NoSuchElementException> {
+            userCreditService.getBalance(userId)
+        }
+        assertEquals("존재하지 않는 사용자입니다.", exception.message)
+    }
 }

--- a/src/test/kotlin/order/application/user/UserCreditServiceTest.kt
+++ b/src/test/kotlin/order/application/user/UserCreditServiceTest.kt
@@ -2,83 +2,77 @@ package order.application.user
 
 import order.domain.user.UserCredit
 import order.domain.user.UserCreditRepository
-import io.mockk.MockKAnnotations
-import io.mockk.Runs
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
-class UserCreditServiceTest {
+class UserCreditServiceTest : DescribeSpec({
 
-    private lateinit var userCreditRepository: UserCreditRepository
-    private lateinit var userCreditService: UserCreditService
+    val userCreditRepository = mockk<UserCreditRepository>(relaxed = true)
+    val userCreditService = UserCreditService(userCreditRepository)
 
-    @BeforeEach
-    fun setUp() {
-        MockKAnnotations.init(this)
-        userCreditRepository = mockk(relaxed = true)
-        userCreditService = UserCreditService(userCreditRepository)
-    }
+    describe("charge") {
+        context("정상적인 userId와 크레딧이 주어졌을 때") {
+            it("chargeCredits를 호출한다") {
+                // given
+                val userId = 1L
+                val credits = 1000
 
-    @Test
-    fun `정상적으로 크레딧 충전`() {
-        // given
-        val userId = 1L
-        val credits = 1000
-        val user = mockk<UserCredit>()
+                // when
+                userCreditService.charge(userId, credits)
 
-        every { userCreditRepository.chargeCredits(userId, credits) } just Runs
-
-        // when
-        userCreditService.charge(userId, credits)
-
-        // then
-        verify { userCreditRepository.chargeCredits(userId, credits) }
-    }
-
-    @Test
-    fun `존재하지 않는 사용자 예외`() {
-        // given
-        val userId = 2L
-        every { userCreditRepository.chargeCredits(userId, any()) } throws NoSuchElementException("존재하지 않는 사용자입니다.")
-
-        // when & then
-        val exception = assertThrows<NoSuchElementException> {
-            userCreditService.charge(userId, 100)
+                // then
+                verify { userCreditRepository.chargeCredits(userId, credits) }
+            }
         }
-        assertEquals("존재하지 않는 사용자입니다.", exception.message)
-    }
 
-    @Test
-    fun `정상적으로 크레딧 잔액 조회`() {
-        // given
-        val userId = 1L
-        val userCredit = UserCredit(id = userId, credits = 5000)
-        every { userCreditRepository.findById(userId) } returns userCredit
+        context("존재하지 않는 사용자 userId가 주어졌을 때") {
+            it("NoSuchElementException을 던진다") {
+                // given
+                val userId = 2L
+                every { userCreditRepository.chargeCredits(userId, any()) } throws NoSuchElementException("존재하지 않는 사용자입니다.")
 
-        // when
-        val result = userCreditService.getBalance(userId)
-
-        // then
-        assertEquals(userId, result.id)
-        assertEquals(5000, result.credits)
-    }
-
-    @Test
-    fun `존재하지 않는 사용자 잔액 조회 예외`() {
-        // given
-        val userId = 999L
-        every { userCreditRepository.findById(userId) } returns null
-
-        // when & then
-        val exception = assertThrows<NoSuchElementException> {
-            userCreditService.getBalance(userId)
+                // when & then
+                val exception = shouldThrow<NoSuchElementException> {
+                    userCreditService.charge(userId, 100)
+                }
+                exception.message shouldBe "존재하지 않는 사용자입니다."
+            }
         }
-        assertEquals("존재하지 않는 사용자입니다.", exception.message)
     }
-}
+
+    describe("getBalance") {
+        context("존재하는 userId가 주어졌을 때") {
+            it("UserCredit을 반환한다") {
+                // given
+                val userId = 1L
+                val userCredit = UserCredit(id = userId, credits = 5000)
+                every { userCreditRepository.findById(userId) } returns userCredit
+
+                // when
+                val result = userCreditService.getBalance(userId)
+
+                // then
+                result.id shouldBe userId
+                result.credits shouldBe 5000
+            }
+        }
+
+        context("존재하지 않는 userId가 주어졌을 때") {
+            it("NoSuchElementException을 던진다") {
+                // given
+                val userId = 999L
+                every { userCreditRepository.findById(userId) } returns null
+
+                // when & then
+                val exception = shouldThrow<NoSuchElementException> {
+                    userCreditService.getBalance(userId)
+                }
+                exception.message shouldBe "존재하지 않는 사용자입니다."
+            }
+        }
+    }
+})


### PR DESCRIPTION
## Summary

- **Task #1** (`#21`): `GET /api/order/credit/{userId}` — 크레딧 잔액 조회 API 구현
- **Task #2** (`#22`): `GET /api/order/history/{userId}` — 주문 내역 조회 API 구현

## 변경 사항

### Task #1 - 크레딧 잔액 조회
- `CreditBalanceResponse` DTO 추가
- `UserCreditService.getBalance()` 추가 (`@Transactional(readOnly=true)`)
- `OrderController` `GET /credit/{userId}` 엔드포인트 추가
- `GlobalExceptionHandler` `NoSuchElementException` → 404 처리 추가

### Task #2 - 주문 내역 조회
- `OrderHistoryResult` 도메인 클래스 추가 (history + details 결합)
- `OrderHistoryResponse` / `OrderDetailResponse` DTO 추가
- `OrderRepository.findByUserId()` 인터페이스 추가
- `OrderJpaRepository` JOIN FETCH 쿼리 추가 (N+1 방지)
- `OrderService.findOrdersByUserId()` 추가 (`@Transactional(readOnly=true)`)
- `OrderController` `GET /history/{userId}` 엔드포인트 추가

## Test plan

- [x] `UserCreditServiceTest` — getBalance 단위 테스트 2개 통과
- [x] `OrderControllerUnitTest` — getCredit / findOrderHistory 단위 테스트 통과
- [x] `OrderControllerIntegrationTest` — 통합 테스트 전체 통과
- [x] 전체 테스트 `BUILD SUCCESSFUL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)